### PR TITLE
Point submodules to Patrick's forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,14 +1,12 @@
 [submodule "extern/fabm"]
 	path = extern/fabm
-	url = https://github.com/fabm-model/fabm
-#	url = ../../fabm-model/fabm
+	url = https://github.com/PatrickFarnole/fabm
 [submodule "extern/flexout"]
 	path = extern/flexout
-	url = https://github.com/BoldingBruggeman/flexout
-#	url = ../../BoldingBruggeman/flexout
+	url = https://github.com/PatrickFarnole/flexout
 [submodule "extern/stim"]
 	path = extern/stim
-	url = https://github.com/BoldingBruggeman/stim
+	url = https://github.com/PatrickFarnole/stim
 [submodule "extern/CVMix-src"]
 	path = extern/CVMix-src
 	url = https://github.com/CVMix/CVMix-src.git


### PR DESCRIPTION
Updates the .gitmodules in the main GOTM repository to point to @PatrickFarnole's forks. This will ensure that when the submodules are cloned down, the commits referenced in the super repository are available. This PR should be reverted when @JuliaPutko's work is integrated into the main `fabm`, `gotm`, and `stim` repositories.

NOTE to @PatrickFarnole: You will also need to fork `fortran-yaml` since `flexout/extern/fortran-yaml` expects that the 'owner' of the `flexout` repository also has `fortran-yaml`. 

